### PR TITLE
Add instructions for mac and windows build installs with ollama

### DIFF
--- a/build_assets/macOS/Packaging_Instructions_macOS.md
+++ b/build_assets/macOS/Packaging_Instructions_macOS.md
@@ -39,3 +39,15 @@ codesign --verify --verbose=4 MORagents.app
 
 codesign -dv --verbose=4 MORagents.app
 ```
+
+## Wizard Creation
+
+1. Download the dev version of the Packages app (it has to be the dev version because the latest build doesn't work on mac sonoma/last updated 2022) [Packages App](http://s.sudre.free.fr/Software/Packages/about.html) [packages_1211_dev.dmg](http://s.sudre.free.fr/files/Packages_1211_dev.dmg)
+2. Download the files in https://github.com/MorpheusAIs/moragents/blob/a9d875b679df3e14e1d0a28704d00c001c99e340/build_assets/windows/, along with [Docker Desktop Mac Install](https://docs.docker.com/desktop/install/mac-install/) and MORAgents.app.
+3. In the Packages App...\
+a) Create a New Project ... set the template as "Distribution".\
+b) Under the Packages, either edit the existing package or create a new one. Set "Identifier" to com.morpheus.pkg.MORAgents, set the Payload to have MORAgents.app under /Applications, then under Scripts, add the preinstall.sh and postinstall.sh from the downloaded files.\
+c) Create a new Package, then under Payload, add the Docker Desktop Mac Install under /Applications\
+d) Create a new Package, then under preinstall scripts, add the preinstall_ollama.sh script from the downloaded files.\
+e) Navigate to Project, then set Presentation to have the welcome.html file and other settings to present the installer.
+

--- a/build_assets/macOS/postinstall.sh
+++ b/build_assets/macOS/postinstall.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Function to check if an application is running
+is_app_running() {
+    app_name=$1
+    pgrep -x "$app_name" >/dev/null
+}
+
+# Open Docker Desktop
+open -a "Docker.app"
+
+# Set the timeout duration (in seconds)
+timeout=300  # 5 minutes
+
+# Wait for Docker Desktop to be running
+echo "Waiting for Docker Desktop to start..."
+start_time=$(date +%s)
+while ! is_app_running "Docker Desktop"; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    
+    if [ $elapsed_time -ge $timeout ]; then
+        echo "Error: Docker Desktop did not start within the specified timeout."
+        exit 1
+    fi
+    
+    sleep 1
+done
+echo "Docker Desktop is running."
+
+# Open MORAgents.app
+open -a "MORAgents.app"
+
+echo "Post-install script completed."
+exit 0

--- a/build_assets/macOS/preinstall.sh
+++ b/build_assets/macOS/preinstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+python_version=$(python3 --version 2>&1 | awk '{print $2}')
+if [[ "$python_version" < "3.12.0" ]]; then
+    echo "Installing Python 3.12.0..."
+    curl -O https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg
+    sudo installer -pkg python-3.12.0-macos11.pkg -target /
+    echo "Python 3.12.0 has been successfully installed."
+    rm python-3.12.0-macos11.pkg
+else
+    echo "Python version is already up to date."
+fi

--- a/build_assets/macOS/preinstall_ollama.sh
+++ b/build_assets/macOS/preinstall_ollama.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -L https://github.com/jmorganca/ollama/releases/download/v0.1.46/ollama-darwin -o ollama
+
+chmod +x ollama
+
+sudo mv ollama /usr/local/bin/

--- a/build_assets/macOS/welcome.html
+++ b/build_assets/macOS/welcome.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to MORAgents Installer</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+    }
+
+    h1 {
+      color: #333;
+    }
+
+    p {
+      color: #666;
+      line-height: 1.5;
+    }
+
+    ul {
+      margin-top: 20px;
+    }
+
+    li {
+      margin-bottom: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Welcome to MORAgents Installer</h1>
+  <p>Thank you for choosing to install MORAgents on your system. This installer will guide you through the process of setting up MORAgents and its dependencies.</p>
+  <p>The installer will perform the following steps:</p>
+  <ul>
+    <li>Check the installed Python version and install Python 3.12.0 if necessary.</li>
+    <li>Check if Docker is installed and install Docker Desktop if needed.</li>
+    <li>Check if Ollama is installed and install Ollama if needed.</li>
+    <li>Install the MORAgents application.</li>
+  </ul>
+  <p>Please note that during the installation process, you may be prompted to enter your system password to authorize the installation of required components.</p>
+  <p>Click "Continue" to proceed with the installation.</p>
+</body>
+</html>
+

--- a/build_assets/windows/Packaging_Instructions_Windows.md
+++ b/build_assets/windows/Packaging_Instructions_Windows.md
@@ -18,4 +18,4 @@ Windows Inno Setup for Wizard:
 2) In the GUI, enter the text found in [wizard_windows.iss](../../wizard_windows.iss)
 3) Click Build > Compile
 4) Hit the Play/Run button on the top
-5) Installer is the 
+5) Installer will run and create a Desktop icon to run the application.

--- a/wizard_windows.iss
+++ b/wizard_windows.iss
@@ -18,6 +18,7 @@ Source: "dist\MORagents\MORagents.exe"; DestDir: "{app}"
 Source: "dist\MORagents\_internal\*"; DestDir: "{app}\_internal"; Flags: recursesubdirs
 Source: "images\moragents.ico"; DestDir: "{app}"
 Source: "resources\Docker Desktop Installer.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "resources\OllamaSetup.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
 Source: "LICENSE"; DestDir: "{app}"; Flags: isreadme
 
 [Icons]
@@ -25,6 +26,8 @@ Name: "{commondesktop}\MORagents"; Filename: "{app}\MORagents.exe"; IconFilename
 
 [Run]
 Filename: "{app}\LICENSE"; Description: "License Agreement"; Flags: postinstall shellexec skipifsilent
+Filename: "{tmp}\Docker Desktop Installer.exe"; Description: "Installing Docker Desktop..."; StatusMsg: "Installing Docker Desktop..."
+Filename: "{tmp}\OllamaSetup.exe"; Description: "Installing Ollama..."; StatusMsg: "Installing Ollama..."
 
 [Code]
 function InitializeSetup(): Boolean;


### PR DESCRIPTION
This PR contains the instructions for installing the mac and windows builds appended with the Ollama dependency.