### PR TITLE
initial benchmarking for data ingester (price & market cap)

### DIFF
--- a/submodules/benchmarks/adapters/base_adapter.py
+++ b/submodules/benchmarks/adapters/base_adapter.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+class BaseAdapter(ABC):
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_price(self, coin_id: str) -> float:
+        pass
+
+    def get_marketcap(self, coin_id: str) -> float:
+        pass
+
+    def has_get_marketcap(self) -> bool:
+        return hasattr(self, 'get_marketcap') and callable(getattr(self, 'get_marketcap'))
+
+    def has_get_price(self) -> bool:
+        return hasattr(self, 'get_price') and callable(getattr(self, 'get_price'))

--- a/submodules/benchmarks/adapters/coincap_adapter.py
+++ b/submodules/benchmarks/adapters/coincap_adapter.py
@@ -1,0 +1,32 @@
+import requests
+from .base_adapter import BaseAdapter
+
+# TODO: this needs a coingecko_id -> coincap_id translation layer to be more accurate
+# It mostly works as-is because coincap often shares the same identifier as coingecko
+class CoincapAdapter(BaseAdapter):
+
+    @property
+    def name(self) -> str:
+        return "Coincap"
+
+    def get_price(self, coingecko_id: str) -> float:
+        request_url = f"https://api.coincap.io/v2/rates/{coingecko_id}"
+        response = requests.get(request_url)
+        response.raise_for_status()
+        data = response.json()
+        price = float(data['data']['rateUsd'])
+        return price
+
+    def get_marketcap(self, coingecko_id: str) -> float:
+        request_url = f"https://api.coincap.io/v2/assets/{coingecko_id}"
+        response = requests.get(request_url)
+        response.raise_for_status()
+        data = response.json()
+        marketcap = float(data['data']['marketCapUsd'])
+        return marketcap
+
+    def has_get_marketcap(self) -> bool:
+        return True
+
+    def has_get_price(self) -> bool:
+        return True

--- a/submodules/benchmarks/adapters/coingecko_adapter.py
+++ b/submodules/benchmarks/adapters/coingecko_adapter.py
@@ -1,0 +1,30 @@
+import requests
+from .base_adapter import BaseAdapter
+
+# defillama and coingecko share the same identifiers
+class CoingeckoAdapter(BaseAdapter):
+
+    @property
+    def name(self) -> str:
+        return "Coingecko"
+
+    def get_price(self, coingecko_id: str) -> float:
+        url = f"https://api.coingecko.com/api/v3/simple/price"
+        params = {'ids': coingecko_id, 'vs_currencies': 'usd'}
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+        return response.json()[coingecko_id]['usd']
+
+    def get_marketcap(self, coin_id: str) -> float:
+            request_url = f"https://api.coingecko.com/api/v3/coins/{coin_id}"
+            response = requests.get(request_url)
+            response.raise_for_status()
+            data = response.json()
+            marketcap = data['market_data']['market_cap']['usd']
+            return marketcap
+
+    def has_get_marketcap(self) -> bool:
+        return True
+
+    def has_get_price(self) -> bool:
+        return True

--- a/submodules/benchmarks/adapters/defillama_adapter.py
+++ b/submodules/benchmarks/adapters/defillama_adapter.py
@@ -1,0 +1,22 @@
+import requests
+from .base_adapter import BaseAdapter
+
+class DefillamaAdapter(BaseAdapter):
+
+    @property
+    def name(self) -> str:
+        return "Defillama"
+    
+    def get_price(self, coingecko_id: str) -> float:
+        request_url = f"https://coins.llama.fi/prices/current/coingecko:{coingecko_id}"
+        response = requests.get(request_url)
+        response.raise_for_status()
+        data = response.json()
+        price = data['coins'][f'coingecko:{coingecko_id}']['price']
+        return price
+
+    def has_get_marketcap(self) -> bool:
+        return False
+
+    def has_get_price(self) -> bool:
+        return True

--- a/submodules/benchmarks/benchmarks.py
+++ b/submodules/benchmarks/benchmarks.py
@@ -1,0 +1,52 @@
+import time
+import argparse
+from helpers import ask_data_llm, check_response, extract_llm_usd_value
+from config import coins, price_prompts, mcap_prompts, price_error_tolerance, mcap_error_tolerance
+from adapters.coingecko_adapter import CoingeckoAdapter
+from adapters.defillama_adapter import DefillamaAdapter
+from adapters.coincap_adapter import CoincapAdapter
+
+# Define all adapters
+all_adapters = [
+    CoingeckoAdapter(),
+    DefillamaAdapter(),
+    CoincapAdapter()
+]
+
+# Argument parsing
+parser = argparse.ArgumentParser(description="Specify the type of prompts to use (price or mcap).")
+parser.add_argument('type', choices=['price', 'mcap'], help="Type of prompts to use")
+args = parser.parse_args()
+
+benchmark_type = args.type
+
+# Set prompts based on the specified type
+if benchmark_type == 'price':
+    prompts = price_prompts
+elif benchmark_type == 'mcap':
+    prompts = mcap_prompts
+
+try:
+    print()
+    for prompt in prompts:
+        for coin in coins:
+            coingecko_id = coin["coingecko_id"]
+            for name in coin["names"]:
+                llm_prompt = prompt.format(name)
+                print(f"Checking {coingecko_id}: {llm_prompt}")
+                llm_response = ask_data_llm(prompt.format(name))
+                llm_usd_value = extract_llm_usd_value(llm_response)
+                for adapter in all_adapters:
+                    if benchmark_type == "price":
+                        if adapter.has_get_price():
+                            benchmark_value = adapter.get_price(coingecko_id)
+                            check_response(llm_usd_value, coingecko_id, adapter, name, benchmark_value, price_error_tolerance)
+                    elif benchmark_type == "mcap":
+                        if adapter.has_get_marketcap():
+                            benchmark_value = adapter.get_marketcap(coingecko_id)
+                            check_response(llm_usd_value, coingecko_id, adapter, name, benchmark_value, mcap_error_tolerance)
+                time.sleep(10) # must to be high for coingecko rate limits
+                print()
+except Exception as e:
+    print(f"Unexpected error: {e}")
+    exit(1)

--- a/submodules/benchmarks/config.py
+++ b/submodules/benchmarks/config.py
@@ -1,0 +1,31 @@
+price_error_tolerance = 0.01 # 1% error tolerance
+mcap_error_tolerance = 0.01 # 1% error tolerance
+
+coins = [
+    {
+        "coingecko_id": "bitcoin",
+        "names": ["bitcoin", "Bit coin", "expected_to_fail"]
+    },
+    {
+        "coingecko_id": "litecoin",
+        "names": ["litecoin", "ltc"]
+    },
+    {
+        "coingecko_id": "xrp",
+        "names": ["ripple", "xrp"]
+    },
+    {
+        "coingecko_id": "expected_to_fail",
+        "names": ["bitcoin"]
+    },
+]
+
+price_prompts = [
+    "What is the price of {}?",
+    "How much does {} cost?",
+]
+
+mcap_prompts = [
+    "What is the market capitalization of {}?",
+    "Whats {}'s market cap?",
+]

--- a/submodules/benchmarks/helpers.py
+++ b/submodules/benchmarks/helpers.py
@@ -1,0 +1,62 @@
+import requests
+import json
+import re
+from adapters.base_adapter import BaseAdapter
+from config import price_error_tolerance, mcap_error_tolerance
+
+url = 'http://127.0.0.1:8080/data_agent/'
+
+headers = {
+    'Accept': 'application/json, text/plain, */*',
+    'Accept-Language': 'en-US,en;q=0.9',
+    'Connection': 'keep-alive',
+    'Content-Type': 'application/json',
+    'Origin': 'http://localhost:3333',
+    'Referer': 'http://localhost:3333/',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'cross-site',
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+    'sec-ch-ua': '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+}
+
+def ask_data_agent(prompt: str):
+    payload = {
+        "prompt": {
+            "role": "user",
+            "content": prompt
+        }
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(payload))
+    
+    result_content = response.json()['content']
+    return result_content
+
+def extract_llm_usd_value(content: str):
+    match = re.search(r'\$\d+(?:,\d{3})*(?:\.\d{1,8})?', content) # 8 usd digits should be plenty
+    if match:
+        price_str = match.group(0).replace('$', '').replace(',', '')
+        return float(price_str)
+    return None
+
+def check_response(llm_value: float, coin_id: str, adapter: BaseAdapter, name: str, benchmark_value: float, error_tolerance: float):
+    if benchmark_value is None or llm_value is None:
+        result = f"{adapter.name} FAIL"
+        if benchmark_value is None and llm_value is None:
+            result_message = f"Failed to get benchmark and agent for {coin_id} and {name}"
+        elif benchmark_value is None:
+            result_message = f"Failed to get benchmark for {coin_id}"
+        elif llm_value is None:
+            result_message = f"Failed to get agent for {name}"
+    else:
+        difference = abs(llm_value - benchmark_value)
+        percent_difference = (difference / benchmark_value) * 100
+        result_message = f"${llm_value:.8f} / ${benchmark_value:.8f}, {percent_difference:.2f}% off"
+        if percent_difference <= error_tolerance * 100:
+            result = f"{adapter.name} PASS"
+        else:
+            result = f"{adapter.name} FAIL"
+
+    print(f"{result} {result_message}")

--- a/submodules/benchmarks/helpers.py
+++ b/submodules/benchmarks/helpers.py
@@ -34,7 +34,7 @@ def ask_data_agent(prompt: str):
     result_content = response.json()['content']
     return result_content
 
-def extract_llm_usd_value(content: str):
+def extract_agent_usd_value(content: str):
     match = re.search(r'\$\d+(?:,\d{3})*(?:\.\d{1,8})?', content) # 8 usd digits should be plenty
     if match:
         price_str = match.group(0).replace('$', '').replace(',', '')

--- a/submodules/benchmarks/helpers.py
+++ b/submodules/benchmarks/helpers.py
@@ -41,19 +41,19 @@ def extract_agent_usd_value(content: str):
         return float(price_str)
     return None
 
-def check_response(llm_value: float, coin_id: str, adapter: BaseAdapter, name: str, benchmark_value: float, error_tolerance: float):
-    if benchmark_value is None or llm_value is None:
+def check_response(agent_value: float, coin_id: str, adapter: BaseAdapter, name: str, benchmark_value: float, error_tolerance: float):
+    if benchmark_value is None or agent_value is None:
         result = f"{adapter.name} FAIL"
-        if benchmark_value is None and llm_value is None:
+        if benchmark_value is None and agent_value is None:
             result_message = f"Failed to get benchmark and agent for {coin_id} and {name}"
         elif benchmark_value is None:
             result_message = f"Failed to get benchmark for {coin_id}"
-        elif llm_value is None:
+        elif agent_value is None:
             result_message = f"Failed to get agent for {name}"
     else:
-        difference = abs(llm_value - benchmark_value)
+        difference = abs(agent_value - benchmark_value)
         percent_difference = (difference / benchmark_value) * 100
-        result_message = f"${llm_value:.8f} / ${benchmark_value:.8f}, {percent_difference:.2f}% off"
+        result_message = f"${agent_value:.8f} / ${benchmark_value:.8f}, {percent_difference:.2f}% off"
         if percent_difference <= error_tolerance * 100:
             result = f"{adapter.name} PASS"
         else:

--- a/submodules/benchmarks/readme.md
+++ b/submodules/benchmarks/readme.md
@@ -2,9 +2,9 @@
 
 ## About
 
--- Measures how accurately the data agent responds vs benchmark values from coinecko, defillama, coincap, etc.
+- Measures how accurately the data agent responds for price & market cap vs benchmark values from coinecko, defillama, coincap, etc.
 
--Tests every combination of coins & prompts defined in `config.py` against each of the benchmark adapters.
+- Tests every combination of coins & prompts defined in `config.py` against each of the benchmark adapters.
 
 ## Running
 

--- a/submodules/benchmarks/readme.md
+++ b/submodules/benchmarks/readme.md
@@ -1,0 +1,19 @@
+# Data Agent Benchmarking Tests
+
+## About
+
+-- Measures how accurately the data agent responds vs benchmark values from coinecko, defillama, coincap, etc.
+
+-Tests every combination of coins & prompts defined in `config.py` against each of the benchmark adapters.
+
+## Running
+
+## 1. Modify `config.py` with new prompts & coins (if needed)
+## 2. Run `pip install -r requirements.txt`
+## 2. Run `python benchmarks.py price` for price benchmarks or `python benchmarks.py mcap` for market cap
+
+## Considerations
+
+- The source of truth asset id is the coingecko id. Any new adapters will need some way of translating the coingecko id if they use something else. For example, the coincap doesn't use the same id format as coingecko and will need a translation layer (TODO).
+
+- Disabling coingecko adapter lets us reduce the `time.sleep()` in `benchmarks.py` and run much faster (rate limiting).

--- a/submodules/benchmarks/requirements.txt
+++ b/submodules/benchmarks/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/submodules/moragents_dockers/agents/Dockerfile-apple
+++ b/submodules/moragents_dockers/agents/Dockerfile-apple
@@ -1,4 +1,4 @@
-FROM arm64v8/python:3.10-bullseye
+FROM --platform=linux/arm64 python:3.10-bullseye
 
 # Set the working directory in the container
 WORKDIR /app

--- a/submodules/moragents_dockers/agents/requirements.txt
+++ b/submodules/moragents_dockers/agents/requirements.txt
@@ -6,6 +6,6 @@ scikit-learn
 huggingface-hub
 flask==2.2.2
 Werkzeug==2.2.2
-gradio > /dev/null
+gradio
 flask-cors
 web3


### PR DESCRIPTION
Benchmarks to measures how accurately the data agent responds with price & market cap vs benchmark values from coinecko, defillama, coincap, etc.

Generates agent prompts from values defined in `config.py` and validates them against each of the benchmark adapters.

Running:

1. `cd submodules/benchmarks`
2. Modify `config.py` with new prompts, coins & error tolerances
3. Run `pip install -r requirements.txt`
4. Run `python benchmarks.py price` for price benchmarks
5. Run `python benchmarks.py mcap` for market cap benchmarks

Considerations:

- It runs very slow because of coingecko rate limiting. Disabling coingecko adapter lets us reduce the `time.sleep()` in `benchmarks.py` and run much faster.

- The id for source of truth for benchmarking adapter calls is the coingecko id. Any new adapters will need some way of translating the coingecko id if they use something else. For example, the coincap doesn't use the same id format as coingecko and will need some kind of translation layer (TODO).

